### PR TITLE
Add missing case to serve TimeoutNow requests

### DIFF
--- a/rafthttp.go
+++ b/rafthttp.go
@@ -283,6 +283,8 @@ func (t *HTTPTransport) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		rpc.Command = &raft.RequestVoteRequest{}
 	case "AppendEntries":
 		rpc.Command = &raft.AppendEntriesRequest{}
+	case "TimeoutNow":
+		rpc.Command = &raft.TimeoutNowRequest{}
 	default:
 		http.Error(res, fmt.Sprintf("No RPC %q", cmd), 404)
 		return


### PR DESCRIPTION
Without this case, valid TimeoutNow requests return a 404 error, even though the request is fully implemented in RobustIRC.